### PR TITLE
Switching to DNS names

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
@@ -21,7 +21,6 @@
       with_items:
       - primary_master
       - api_url
-      - router_service
       - router_dc
       - registry_service
       - canary_route

--- a/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
@@ -5,7 +5,7 @@
   tasks:
     - name: Check for cluster var
       fail:
-        msg: "Please define cluster on the command line, to load the correct variable file"
+        msg: "Please define cluster on the command line with --extra-vars cluster=<cluster> , to load the correct variable file"
       when: "cluster is undefined"
 
 - name: OCP Monitoring

--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -159,11 +159,10 @@ fi
 
 {% if ansible_fqdn == primary_master %}
 # Test that the Router service is responding
-# TODO switch to DNS name once server are using dnsmasq properly
 echo -n "$(datestamp) OpenShift Router Status: "
-if ! ${CURL} {{ router_service }}/healthz | grep 'Service ready'
+if ! ${CURL} http://router.default.svc:1936/healthz | grep 'Service ready'
 then
-  echo "$(datestamp) ERROR: curl of router service {{ router_service }}/healthz failed"
+  echo "$(datestamp) ERROR: curl of router service http://router.default.svc:1936/healthz failed"
 fi
 
 # Test that a sample route is working

--- a/utils/ansible-playbooks/deploy-monitoring/vars/lab.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/vars/lab.yaml
@@ -1,7 +1,6 @@
 ---
 primary_master: ociopf-t-301.dmz
 api_url: https://console.lab.pathfinder.gov.bc.ca:8443
-router_service: http://router.default.svc:1936
 router_dc: ipf-ha-router
 registry_service: https://docker-registry.default.svc:5000
 canary_route: https://canary.lab.pathfinder.gov.bc.ca/

--- a/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
@@ -1,7 +1,6 @@
 ---
 primary_master: ociopf-d-100.dmz
 api_url: https://console.pathfinder.gov.bc.ca:8443
-router_service: http://router.default.svc:1936
 router_dc: ipf-ha-router-kamloops
 registry_service: http://docker-registry.default.svc:5000
 canary_route: https://bcdevexchange.org/

--- a/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
@@ -1,8 +1,8 @@
 ---
 primary_master: ociopf-d-100.dmz
 api_url: https://console.pathfinder.gov.bc.ca:8443
-router_service: http://172.50.56.219:1936
+router_service: http://router.default.svc:1936
 router_dc: ipf-ha-router-kamloops
-registry_service: http://172.50.0.2:5000
+registry_service: http://docker-registry.default.svc:5000
 canary_route: https://bcdevexchange.org/
 metrics_url: https://hawkular-metrics.pathfinder.gov.bc.ca

--- a/utils/ansible-playbooks/deploy-monitoring/vars/test.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/vars/test.yaml
@@ -1,9 +1,9 @@
 ---
 primary_master: ociopf-t-301.dmz
 api_url: https://console.lab.pathfinder.gov.bc.ca:8443
-router_service: http://10.131.7.73:1936
+router_service: http://router.default.svc:1936
 router_dc: ipf-ha-router
-registry_service: http://10.131.6.232:5000
+registry_service: https://docker-registry.default.svc:5000
 canary_route: https://canary.lab.pathfinder.gov.bc.ca/
 metrics_url: https://hawkular-metrics.lab.pathfinder.gov.bc.ca
 cron_hour: "9-15"


### PR DESCRIPTION
Use router.default.svc and docker-registry.default.svc instead of IP
addresses.
Switch the LAB to use https for docker-registry