### PR TITLE
Change cron entry to log STDERR

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/deploy.yaml
@@ -51,5 +51,5 @@
         cron_file: /etc/cron.d/ocp-monitor
         user: root
         minute: "*/5"
-        job: /usr/local/bin/ocp-monitor 2>&1 >> /var/log/ocp-monitor.log
+        job: /usr/local/bin/ocp-monitor >> /var/log/ocp-monitor.log 2>&1
 


### PR DESCRIPTION
Having the 2>&1 before the redirection to a file caused it to still end
up on STDOUT instead of in the log file.