### PR TITLE
Separate curl from its test

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -157,7 +157,8 @@ function return_node_ready_count () {
 
 # Test that the API is responding
 echo -n "$(datestamp) OpenShift API Status: "
-if ! STATUS=$(${CURL} {{ api_url }}/healthz 2>&1 | grep ok)
+STATUS=$(${CURL} {{ api_url }}/healthz 2>&1)
+if ! echo "${STATUS}" | grep ok
 then
   echo -e "${STATUS}"
   MSG=$(echo "$(datestamp) ERROR: curl of API {{ api_url }}/healthz failed")
@@ -170,7 +171,8 @@ fi
 {% if ansible_fqdn == primary_master %}
 # Test that the Router service is responding
 echo -n "$(datestamp) OpenShift Router Status: "
-if ! STATUS=$(${CURL} http://router.default.svc:1936/healthz 2>&1 | grep -i OK)
+STATUS=$(${CURL} http://router.default.svc:1936/healthz 2>&1)
+if ! echo "${STATUS}" | grep -i OK
 then
   MSG=$(echo -e "\n$(datestamp) ERROR: curl of router service http://router.default.svc:1936/healthz failed\n${STATUS}")
   echo -e "${MSG}"
@@ -183,7 +185,9 @@ fi
 echo "$(datestamp) Canary Route Status"
 get_state canaryhealth CANARY_HEALTH_STATE
 # Use --insecure in case there are TLS cert issues
-if ! STATUS=$(${CURL} --head --insecure {{ canary_route }} 2>&1 | grep '200 OK'); then
+STATUS=$(${CURL} --head --insecure {{ canary_route }} 2>&1)
+if ! echo "${STATUS}" | grep '200 OK'
+then
 
   if [[ "${CANARY_HEALTH_STATE}" -eq "0" ]]; then
 # canary health check failure while in state 0, bumps us to state 1 and warns only
@@ -221,7 +225,8 @@ fi
 # TOD switch to DNS name once server is using dnsmasq properly
 echo -n "$(datestamp) Docker Registry Status: "
 # Use --head as this enpoint returns an empty document
-if ! STATUS=$(${CURL} --head {{ registry_service }}/healthz 2>&1 | grep '200 OK')
+STATUS=$(${CURL} --head {{ registry_service }}/healthz 2>&1)
+if ! echo "${STATUS}" | grep '200 OK'
 then
   MSG=$(echo -e"\n$(datestamp) ERROR: curl of docker registry service {{ registry_service }}/healthz failed\n${STATUS}")
   echo -e "${MSG}"


### PR DESCRIPTION
Perform Curl separate from testing its output so that any errors
produced can be printed to the log