### PR TITLE
Workaround for broken system certificate playbook

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/templates/cert-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/cert-monitor.j2
@@ -19,7 +19,7 @@ MAILFROM="-r hslinuxteam@dxcas.com"
 EMAIL_ENV="{{ email_env }}"
 
 # Run the playbook
-if ! PLAYBOOK_RUN=$(/usr/bin/ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/openshift-checks/certificate_expiry/default.yaml 2>&1)
+if ! PLAYBOOK_RUN=$(/usr/bin/ansible-playbook /usr/local/bin/certificate_expiry/default.yaml 2>&1)
 then
   echo -e "${PLAYBOOK_RUN}" | mail -a /tmp/cert-expiry-report.html -s "${EMAIL_ENV} ERROR - Cert Monitor Playbook Failed!" $MAILFROM $MAILTO
   exit 1


### PR DESCRIPTION
Stock Red Hat playbook for checking certificate expiry once we completed the 3.10.72 security upgrade.

A copy of the playbook directory before upgrading in PROD was saved, and the required components isolated. This PR proposes pointing the active daily cron to the isolated copy of the working playbook.

Hopefully Red Hat will fix their playbook in the form of a new RPM package before we attempt OCP 3.11 upgrade in January. 