### PR TITLE
Add new state check for critical situation versus minor loss of redun…

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -381,13 +381,43 @@ else
 fi
 
 # Verify the Registry is on 3 nodes
+# Stateful health checks. The following document the used states and their meaning.
+# State 0 (S0). Descriptively called the "INFO" state, this state means nothing is wrong at all, and if the service
+#                check was already clear, will generate an "INFO" message to the logs. If this state is reached as a result
+#                of clearing one of the previous states, then a "RECOVERY" message will be sent out as well, so that outside
+#                parties know when a service has in fact recovered rather than assume the lack of new error messages means
+#                all is well.
+# State 1 (S1). Descriptively called the "WARN" state, this state means full redundancy of service has
+#               been compromised, but not enough to cause immediate concern. The on-call group should not be
+#               bothered with events of a WARN nature. If t
+# State 2 (S2). Descriptively called the "ERROR" state, this state can mean at least one of the following scenarios.
+#               - the previous check put us into a WARN state (S1) and services are still not 100% healthy.
+#               - the previous check was also an ERROR state, thus we latch onto this state until health checks improve.
+#               - the previous check was an INFO state, but the current health of the service is such that we need to
+#                 immediately jump to an ERROR state because the health is such that redundancy of the service is
+#                 threatened (one or zero pods available for the service).
+
 NODES=$(oc -n default get pods -l deploymentconfig=docker-registry -o yaml -o go-template="{{range .items}}{{if eq .status.phase \"Running\"}}{{.spec.nodeName}}{{print \"\n\"}}{{end}}{{end}}")
 POD_COUNT=$(echo "${NODES}" | wc -l)
 UNIQ_NODES=$(echo "${NODES}" | sort | uniq | wc -l)
 echo "$(datestamp) Check that Registry is scaled to 3: ${POD_COUNT}"
 echo "$(datestamp) Check that Registry is scaled to all infra nodes: " ${UNIQ_NODES}
 get_state registrypodcount REGISTRY_POD_STATE
-if [[ ("${POD_COUNT}" -lt 3) || ("${UNIQ_NODES}" -lt 3) ]]; then
+if [[ ("${POD_COUNT}" -lt 2) || ("${UNIQ_NODES}" -lt 2) ]]; then
+# does not matter what state we were in previously. We jump directly to S2 (ERROR) state.
+  set_state registrypodcount 2
+  if [[ ("${POD_COUNT}" -lt 2) && ("${UNIQ_NODES}" -lt 2) ]]; then
+    MSG=$(echo "$(datestamp) CRITICAL ERROR: Registry pod count ${POD_COUNT} is less than 2 and Registry running on too few infra nodes: " ${NODES})
+  elif [[ "${POD_COUNT}" -lt 2 ]]; then
+    MSG=$(echo "$(datestamp) CRITICAL ERROR: Registry pod count ${POD_COUNT} is less than 2")
+  elif [[ "${UNIQ_NODES}" -lt 2 ]]; then
+    MSG=$(echo "$(datestamp) CRITICAL ERROR: Registry running on too few infra nodes " ${NODES})
+  fi
+# for convenience include actual pod status for registry pods to save time investigating
+  MSG="${MSG}\n$(oc -n default get pods -o wide -l deploymentconfig=docker-registry)"
+  echo -e "${MSG}"
+  echo -e "${MSG}" | mail -s "${EMAIL_ENV} CRITICAL ERROR event for RegistryPodCheck on $(hostname)" $MAILFROM ${MAILTO}
+elif [[ ("${POD_COUNT}" -lt 3) || ("${UNIQ_NODES}" -lt 3) ]]; then
 
   if [[ "${REGISTRY_POD_STATE}" -eq "0" ]]; then
 # health check failure while in state 0, bumps us to state 1 and warns only


### PR DESCRIPTION
…dancy. Only added to registry pod health check for now. Verbose comments for now, may add such comments to the rest of the stateful checks, or otherwise outside such to a suitable markdown document.