### PR TITLE
Modified PROD registry URL to reflect secured status

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
+++ b/utils/ansible-playbooks/deploy-monitoring/vars/prod.yaml
@@ -2,7 +2,7 @@
 primary_master: ociopf-d-100.dmz
 api_url: https://console.pathfinder.gov.bc.ca:8443
 router_dc: ipf-ha-router-kamloops
-registry_service: http://docker-registry.default.svc:5000
+registry_service: https://docker-registry.default.svc:5000
 canary_route: https://bcdevexchange.org/
 metrics_url: https://hawkular-metrics.pathfinder.gov.bc.ca
 email_env: "OPENSHIFT CLUSTER MONITORING - PROD"


### PR DESCRIPTION
We recently secured the registry in PROD - need to adjust the PROD variable accordingly so that checks no longer attempt regular http connection instead of https.