### PR TITLE
Coredump changes

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -1194,7 +1194,7 @@ if STATUS=$(cd / && ls -lht $(/sbin/sysctl kernel.core_pattern | awk '{print $3}
 then
   MSG=$(echo -e "$(datestamp) WARN: Core files found\n${STATUS}")
   echo -e "${MSG}"
-  echo -e "${MSG}" | mail -s "${EMAIL_ENV} WARN event for Core File Check on `hostname`" $MAILFROM $MAILTOINTERNA
+  echo -e "${MSG}" | mail -s "${EMAIL_ENV} WARN event for Core File Check on `hostname`" $MAILFROM $MAILTOINTERNAL
 fi
 
 # Check and return applicable PIDs matching docker-containerd-current. If nothing is returned, then it may have been killed off.

--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -14,7 +14,7 @@ set -o pipefail
 # Global variables re-used through the script.
 MSG=""
 MAILTO="William.Hutchison@dxcas.com Steven.Barre@dxcas.com Dan.Deane@dxcas.com bcdevex@arctiq.ca Shea.Phillips@gov.bc.ca"
-#MAILTO="William.Hutchison@dxcas.com Steven.Barre@dxcas.com"
+MAILTOINTERNAL="William.Hutchison@dxcas.com Steven.Barre@dxcas.com Dan.Deane@dxcas.com"
 MAILFROM="-r hslinuxteam@dxcas.com"
 
 # Define defaults for Curl
@@ -1194,7 +1194,7 @@ if STATUS=$(cd / && ls -lht $(/sbin/sysctl kernel.core_pattern | awk '{print $3}
 then
   MSG=$(echo -e "$(datestamp) WARN: Core files found\n${STATUS}")
   echo -e "${MSG}"
-  echo -e "${MSG}" | mail -s "${EMAIL_ENV} WARN event for Core File Check on `hostname`" $MAILFROM $MAILTO
+  echo -e "${MSG}" | mail -s "${EMAIL_ENV} WARN event for Core File Check on `hostname`" $MAILFROM $MAILTOINTERNA
 fi
 
 # Check and return applicable PIDs matching docker-containerd-current. If nothing is returned, then it may have been killed off.

--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -1192,9 +1192,9 @@ fi
 echo "$(datestamp) Check for presence of Core files"
 if STATUS=$(cd / && ls -lht $(/sbin/sysctl kernel.core_pattern | awk '{print $3}')*);
 then
-  MSG=$(echo -e "$(datestamp) ERROR: Core files found\n${STATUS}")
+  MSG=$(echo -e "$(datestamp) WARN: Core files found\n${STATUS}")
   echo -e "${MSG}"
-  echo -e "${MSG}" | mail -s "${EMAIL_ENV} ERROR event for Core File Check on `hostname`" $MAILFROM $MAILTO
+  echo -e "${MSG}" | mail -s "${EMAIL_ENV} WARN event for Core File Check on `hostname`" $MAILFROM $MAILTO
 fi
 
 # Check and return applicable PIDs matching docker-containerd-current. If nothing is returned, then it may have been killed off.


### PR DESCRIPTION
The rationale of the changes is to immediately relieve ESIT on-call staff of being woke up in the middle of the night to just move a core dump file out of the way. 

Most if not all of the original core dump concerns have been addressed via other checks as well as ensuring core dumps have a dedicated home. As such these alerts on all nodes will be downgraded to WARN only, which will only go to ESIT staff for investigation next business day.

If this need changes then additional pre-checks will need to be determined to allow more intelligence on how we monitor and alert for this.