### PR TITLE
Changed disk space thresholds for WARN/ALERT

### DIFF
--- a/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
+++ b/utils/ansible-playbooks/deploy-monitoring/templates/ocp-monitor.j2
@@ -338,8 +338,8 @@ echo "$(datestamp) Prometheus Pod Disk Space Checks: "
 for POD in $(oc -n openshift-monitoring get pods --selector "prometheus=k8s" --no-headers -o=custom-columns=NAME:.metadata.name)
 do
   SPACE=$(oc -n openshift-monitoring -c prometheus exec $POD -- sh -c 'echo "$(df /prometheus | awk '\''/prometheus/ {print $5}'\'' | tr -d "%")"')
-  WARNFREE=$(echo 100 '-' $SPACE '>' 25 | bc -l)
-  ERRORFREE=$(echo 100 '-' $SPACE '>' 15 | bc -l)
+  WARNFREE=$(echo 100 '-' $SPACE '>' 20 | bc -l)
+  ERRORFREE=$(echo 100 '-' $SPACE '>' 10 | bc -l)
   if [ "$ERRORFREE" -lt 1 ]
   then
     MSG=$(echo "$(datestamp) ERROR: Low Prometheus Disk Space on pod $POD - $(echo 100 '-' $SPACE | bc -l)% free")


### PR DESCRIPTION
Original limits were 75% for WARN, 85% for ALERT. Changed to 80% for WARN, and 90% for ALERT, on the sole basis that the peak usage is going to linger consistently-close to the original WARN threshold.